### PR TITLE
[codex] add RoundNFC COS direct upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,17 @@ Endpoints (mounted at `/api/roundnfc` by default):
 | GET    | `/admin/me`                                | JWT      | Probe                                  |
 | GET/POST/PUT/DELETE | `/admin/badges[...]`              | JWT      | Badge CRUD                             |
 | POST   | `/admin/badges/:id/image`                  | JWT      | Replace badge image (multipart)        |
+| POST   | `/admin/uploads/presign`                   | JWT / X-App-Token | Return 5-minute COS PUT URL     |
+| POST   | `/admin/nfc-writes`                        | JWT / X-App-Token | Save NFC write metadata + photo key |
 | GET/PATCH | `/admin/photo-requests[...]`            | JWT      | List + status update                   |
 | GET/PATCH | `/admin/autograph-requests[...]`        | JWT      | List + status update                   |
+
+For Android direct COS upload, configure `ROUNDNFC_COS_BUCKET`,
+`ROUNDNFC_COS_REGION`, `ROUNDNFC_COS_SECRET_ID`, `ROUNDNFC_COS_SECRET_KEY`, and
+optionally `ROUNDNFC_ADMIN_APP_TOKEN` on the backend only. The Android client
+calls `/admin/uploads/presign`, uploads with HTTP `PUT` to `uploadUrl`, then
+saves only `photoObjectKey` through `/admin/nfc-writes`. Keep the COS bucket
+private; do not store permanent COS URLs in the database.
 
 ## TODO
 

--- a/cmd/roundnfc/main.go
+++ b/cmd/roundnfc/main.go
@@ -46,7 +46,7 @@ func main() {
 		c.AllowOrigins = []string{"http://localhost:5173", "http://127.0.0.1:5173"}
 	}
 	c.AllowCredentials = true
-	c.AddAllowHeaders("Authorization", "Content-Type", "CF-Turnstile-Response")
+	c.AddAllowHeaders("Authorization", "Content-Type", "CF-Turnstile-Response", "X-App-Token")
 	c.MaxAge = 12 * time.Hour
 	engine.Use(cors.New(c))
 

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -67,7 +67,7 @@ func loadConfig() Config {
 	if v := strings.TrimSpace(os.Getenv("HTTP_CORS_CREDENTIALS")); v != "" {
 		allowCreds = strings.EqualFold(v, "true") || v == "1" || strings.EqualFold(v, "yes")
 	}
-	allowHeaders := []string{"CF-Turnstile-Response", "Authorization", "Content-Type"}
+	allowHeaders := []string{"CF-Turnstile-Response", "Authorization", "Content-Type", "X-App-Token"}
 	if v := strings.TrimSpace(os.Getenv("HTTP_CORS_HEADERS")); v != "" {
 		allowHeaders = nil
 		for _, h := range strings.Split(v, ",") {

--- a/internal/roundnfc/admin_auth.go
+++ b/internal/roundnfc/admin_auth.go
@@ -1,0 +1,40 @@
+package roundnfc
+
+import (
+	"crypto/subtle"
+	"net/http"
+
+	"backend-go/internal/auth"
+
+	"github.com/gin-gonic/gin"
+)
+
+func adminRequired(svc *Service) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if validAppToken(c.GetHeader("X-App-Token"), svc.cfg.AdminAppToken) {
+			c.Set(auth.ContextKeySubject, "app-token")
+			c.Next()
+			return
+		}
+
+		raw := auth.ExtractBearer(c.GetHeader("Authorization"))
+		if raw == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"code": 1, "message": "missing token"})
+			return
+		}
+		claims, err := auth.ParseToken(svc.cfg.JWTSecret, raw)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"code": 1, "message": "invalid token"})
+			return
+		}
+		c.Set(auth.ContextKeySubject, claims.Subject)
+		c.Next()
+	}
+}
+
+func validAppToken(got, want string) bool {
+	if len(want) < 16 || got == "" || len(got) != len(want) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(got), []byte(want)) == 1
+}

--- a/internal/roundnfc/cos_presign.go
+++ b/internal/roundnfc/cos_presign.go
@@ -1,0 +1,153 @@
+package roundnfc
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/url"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const cosPresignTTL = 5 * time.Minute
+
+var ErrCOSNotConfigured = errors.New("roundnfc: cos not configured")
+
+type UploadPresign struct {
+	UploadURL string `json:"uploadUrl"`
+	ObjectKey string `json:"objectKey"`
+	Method    string `json:"method"`
+	ExpiresIn int    `json:"expiresIn"`
+}
+
+func (s *Service) PresignUpload(ctx context.Context, badgeID, fileName, contentType, purpose string) (UploadPresign, error) {
+	_ = ctx
+	key, err := buildUploadObjectKey(badgeID, fileName, contentType, purpose)
+	if err != nil {
+		return UploadPresign{}, err
+	}
+	u, err := s.presignCOSPut(key, cosPresignTTL)
+	if err != nil {
+		return UploadPresign{}, err
+	}
+	return UploadPresign{
+		UploadURL: u,
+		ObjectKey: key,
+		Method:    "PUT",
+		ExpiresIn: int(cosPresignTTL / time.Second),
+	}, nil
+}
+
+func buildUploadObjectKey(badgeID, fileName, contentType, purpose string) (string, error) {
+	badgeID = safePathSegment(badgeID)
+	if badgeID == "" {
+		return "", errors.New("badgeId required")
+	}
+	ext, err := uploadExt(fileName, contentType, purpose)
+	if err != nil {
+		return "", err
+	}
+	return path.Join("roundnfc", "nfc-writes", badgeID, uuid.NewString()+ext), nil
+}
+
+func uploadExt(fileName, contentType, purpose string) (string, error) {
+	ct := strings.ToLower(strings.TrimSpace(strings.Split(contentType, ";")[0]))
+	p := strings.ToLower(strings.TrimSpace(purpose))
+	if p == "" || p == "nfc-write" || p == "nfc-writes" || p == "download" || p == "user-download" {
+		if ct == "" {
+			ct = "image/jpeg"
+		}
+		if ct != "image/jpeg" && ct != "image/jpg" {
+			return "", errors.New("nfc write photos must be image/jpeg")
+		}
+		return ".jpg", nil
+	}
+	switch ct {
+	case "image/jpeg", "image/jpg":
+		return ".jpg", nil
+	case "image/webp":
+		return ".webp", nil
+	case "image/png":
+		return ".png", nil
+	}
+	switch strings.ToLower(filepath.Ext(fileName)) {
+	case ".jpg", ".jpeg":
+		return ".jpg", nil
+	case ".webp":
+		return ".webp", nil
+	case ".png":
+		return ".png", nil
+	}
+	return "", errors.New("unsupported contentType")
+}
+
+var unsafePathChars = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)
+
+func safePathSegment(v string) string {
+	v = strings.TrimSpace(v)
+	v = strings.Trim(v, `/\`)
+	return unsafePathChars.ReplaceAllString(v, "_")
+}
+
+func (s *Service) presignCOSPut(objectKey string, ttl time.Duration) (string, error) {
+	cfg := s.cfg
+	if cfg.COSBucket == "" || cfg.COSRegion == "" || cfg.COSSecretID == "" || cfg.COSSecretKey == "" {
+		return "", ErrCOSNotConfigured
+	}
+	scheme := strings.ToLower(strings.TrimSpace(cfg.COSScheme))
+	if scheme != "http" {
+		scheme = "https"
+	}
+	now := time.Now().Unix()
+	exp := now + int64(ttl/time.Second)
+	keyTime := fmt.Sprintf("%d;%d", now, exp)
+	host := fmt.Sprintf("%s.cos.%s.myqcloud.com", cfg.COSBucket, cfg.COSRegion)
+	uri := "/" + strings.TrimLeft(objectKey, "/")
+
+	headerList := "host"
+	httpString := strings.Join([]string{
+		"put",
+		uri,
+		"",
+		"host=" + strings.ToLower(host) + "\n",
+	}, "\n")
+	httpHash := sha1Hex([]byte(httpString))
+	stringToSign := strings.Join([]string{"sha1", keyTime, httpHash, ""}, "\n")
+	signKey := hmacSHA1Hex([]byte(cfg.COSSecretKey), []byte(keyTime))
+	signature := hmacSHA1Hex([]byte(signKey), []byte(stringToSign))
+
+	q := url.Values{}
+	q.Set("q-sign-algorithm", "sha1")
+	q.Set("q-ak", cfg.COSSecretID)
+	q.Set("q-sign-time", keyTime)
+	q.Set("q-key-time", keyTime)
+	q.Set("q-header-list", headerList)
+	q.Set("q-url-param-list", "")
+	q.Set("q-signature", signature)
+
+	return (&url.URL{
+		Scheme:   scheme,
+		Host:     host,
+		Path:     uri,
+		RawQuery: q.Encode(),
+	}).String(), nil
+}
+
+func sha1Hex(b []byte) string {
+	h := sha1.Sum(b)
+	return hex.EncodeToString(h[:])
+}
+
+func hmacSHA1Hex(key, msg []byte) string {
+	mac := hmac.New(sha1.New, key)
+	mac.Write(msg)
+	return hex.EncodeToString(mac.Sum(nil))
+}

--- a/internal/roundnfc/envinit/envinit.go
+++ b/internal/roundnfc/envinit/envinit.go
@@ -30,6 +30,12 @@ func defaultEnv() []byte {
 			"ROUNDNFC_OBJECT_HMAC_KEY=" + randHex(32) + "\n" +
 			"ROUNDNFC_OBJECT_TTL_SECONDS=120\n" +
 			"ROUNDNFC_MAX_UPLOAD_MB=8\n\n" +
+			"# COS direct upload (private bucket; backend signs short PUT URLs)\n" +
+			"ROUNDNFC_COS_BUCKET=\n" +
+			"ROUNDNFC_COS_REGION=\n" +
+			"ROUNDNFC_COS_SECRET_ID=\n" +
+			"ROUNDNFC_COS_SECRET_KEY=\n" +
+			"ROUNDNFC_COS_SCHEME=https\n\n" +
 			"# 风控\n" +
 			"ROUNDNFC_TURNSTILE_SECRET=\n" +
 			"ROUNDNFC_RATELIMIT_PER_MIN=12\n\n" +
@@ -40,6 +46,8 @@ func defaultEnv() []byte {
 			"ROUNDNFC_ADMIN_USERNAME=admin\n" +
 			"ROUNDNFC_ADMIN_PASSWORD=admin\n" +
 			"ROUNDNFC_ADMIN_PASSWORD_HASH=\n" +
+			"# Optional Android/admin app token for selected admin APIs. Keep long and random.\n" +
+			"ROUNDNFC_ADMIN_APP_TOKEN=\n" +
 			"ROUNDNFC_JWT_SECRET=" + randHex(32) + "\n" +
 			"ROUNDNFC_JWT_TTL_HOURS=12\n\n" +
 			"# TOTP (Google Authenticator)\n" +

--- a/internal/roundnfc/handler_admin.go
+++ b/internal/roundnfc/handler_admin.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -140,6 +141,83 @@ func (h *adminHandler) ListPhotoRequests(c *gin.Context) {
 
 type statusPayload struct {
 	Status string `json:"status"`
+}
+
+type uploadPresignPayload struct {
+	BadgeID     string `json:"badgeId"`
+	FileName    string `json:"fileName"`
+	ContentType string `json:"contentType"`
+	Purpose     string `json:"purpose"`
+}
+
+func (h *adminHandler) PresignUpload(c *gin.Context) {
+	var p uploadPresignPayload
+	if err := c.ShouldBindJSON(&p); err != nil {
+		respondError(c, http.StatusBadRequest, "invalid body")
+		return
+	}
+	out, err := h.svc.PresignUpload(c.Request.Context(), p.BadgeID, p.FileName, p.ContentType, p.Purpose)
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrCOSNotConfigured):
+			respondError(c, http.StatusServiceUnavailable, "cos not configured")
+		default:
+			respondError(c, http.StatusBadRequest, err.Error())
+		}
+		return
+	}
+	respondData(c, out)
+}
+
+type nfcWritePayload struct {
+	BadgeID        string `json:"badgeId"`
+	TagUID         string `json:"tagUid"`
+	NDEFURL        string `json:"ndefUrl"`
+	DeviceID       string `json:"deviceId"`
+	WriteStatus    string `json:"writeStatus"`
+	PhotoObjectKey string `json:"photoObjectKey"`
+	WrittenAt      string `json:"writtenAt"`
+}
+
+func (h *adminHandler) CreateNFCWrite(c *gin.Context) {
+	var p nfcWritePayload
+	if err := c.ShouldBindJSON(&p); err != nil {
+		respondError(c, http.StatusBadRequest, "invalid body")
+		return
+	}
+	badgeID := strings.TrimSpace(p.BadgeID)
+	if badgeID == "" {
+		respondError(c, http.StatusBadRequest, "badgeId required")
+		return
+	}
+	photoKey := strings.TrimSpace(p.PhotoObjectKey)
+	if isAbsoluteURL(photoKey) {
+		respondError(c, http.StatusBadRequest, "photoObjectKey must be an object key")
+		return
+	}
+	writtenAt := time.Now().UTC()
+	if strings.TrimSpace(p.WrittenAt) != "" {
+		t, err := time.Parse(time.RFC3339, strings.TrimSpace(p.WrittenAt))
+		if err != nil {
+			respondError(c, http.StatusBadRequest, "invalid writtenAt")
+			return
+		}
+		writtenAt = t.UTC()
+	}
+	w := &NFCWrite{
+		BadgeID:        badgeID,
+		TagUID:         strings.TrimSpace(p.TagUID),
+		NDEFURL:        strings.TrimSpace(p.NDEFURL),
+		DeviceID:       strings.TrimSpace(p.DeviceID),
+		WriteStatus:    strings.TrimSpace(p.WriteStatus),
+		PhotoObjectKey: photoKey,
+		WrittenAt:      writtenAt,
+	}
+	if err := h.svc.store.InsertNFCWrite(c.Request.Context(), w); err != nil {
+		respondError(c, http.StatusInternalServerError, err.Error())
+		return
+	}
+	respondData(c, w)
 }
 
 func (h *adminHandler) UpdatePhotoStatus(c *gin.Context) {

--- a/internal/roundnfc/router.go
+++ b/internal/roundnfc/router.go
@@ -1,7 +1,6 @@
 package roundnfc
 
 import (
-	"backend-go/internal/auth"
 	"backend-go/internal/authflow"
 	"backend-go/internal/roundnfc/envinit"
 
@@ -36,14 +35,16 @@ func AttachTo(engine *gin.Engine, prefix string) error {
 	admin := g.Group("/admin")
 	flow.Mount(admin)
 
-	// badge + request management (require valid JWT)
-	authed := admin.Group("", auth.Required(svc.cfg.JWTSecret))
+	// badge + request management (require valid JWT or app token)
+	authed := admin.Group("", adminRequired(svc))
 	authed.GET("/badges", adm.ListBadges)
 	authed.POST("/badges", adm.UpsertBadge)
 	authed.GET("/badges/:id", adm.GetBadge)
 	authed.PUT("/badges/:id", adm.UpsertBadge)
 	authed.DELETE("/badges/:id", adm.DeleteBadge)
 	authed.POST("/badges/:id/image", adm.UploadBadgeImage)
+	authed.POST("/uploads/presign", adm.PresignUpload)
+	authed.POST("/nfc-writes", adm.CreateNFCWrite)
 	authed.GET("/photo-requests", adm.ListPhotoRequests)
 	authed.PATCH("/photo-requests/:id", adm.UpdatePhotoStatus)
 	authed.GET("/autograph-requests", adm.ListAutographRequests)

--- a/internal/roundnfc/service.go
+++ b/internal/roundnfc/service.go
@@ -34,6 +34,12 @@ type Config struct {
 	ObjectHMACKey     []byte
 	ObjectTTL         time.Duration
 	MaxUploadBytes    int64
+	COSBucket         string
+	COSRegion         string
+	COSSecretID       string
+	COSSecretKey      string
+	COSScheme         string
+	AdminAppToken     string
 	TurnstileSecret   string
 	RateLimitPerMin   int
 	AdminUsername     string
@@ -71,6 +77,12 @@ func ConfigFromEnv() Config {
 		ObjectHMACKey:     []byte(os.Getenv("ROUNDNFC_OBJECT_HMAC_KEY")),
 		ObjectTTL:         time.Duration(atoiOr("ROUNDNFC_OBJECT_TTL_SECONDS", 120)) * time.Second,
 		MaxUploadBytes:    int64(atoiOr("ROUNDNFC_MAX_UPLOAD_MB", 8)) * (1 << 20),
+		COSBucket:         strings.TrimSpace(os.Getenv("ROUNDNFC_COS_BUCKET")),
+		COSRegion:         strings.TrimSpace(os.Getenv("ROUNDNFC_COS_REGION")),
+		COSSecretID:       strings.TrimSpace(os.Getenv("ROUNDNFC_COS_SECRET_ID")),
+		COSSecretKey:      strings.TrimSpace(os.Getenv("ROUNDNFC_COS_SECRET_KEY")),
+		COSScheme:         getStr("ROUNDNFC_COS_SCHEME", "https"),
+		AdminAppToken:     strings.TrimSpace(os.Getenv("ROUNDNFC_ADMIN_APP_TOKEN")),
 		TurnstileSecret:   os.Getenv("ROUNDNFC_TURNSTILE_SECRET"),
 		RateLimitPerMin:   atoiOr("ROUNDNFC_RATELIMIT_PER_MIN", 12),
 		AdminUsername:     getStr("ROUNDNFC_ADMIN_USERNAME", "admin"),

--- a/internal/roundnfc/store.go
+++ b/internal/roundnfc/store.go
@@ -83,6 +83,18 @@ CREATE TABLE IF NOT EXISTS autograph_requests (
   updated_at      DATETIME NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_auto_badge_status ON autograph_requests(badge_id, status, updated_at);
+CREATE TABLE IF NOT EXISTS nfc_writes (
+  id               TEXT PRIMARY KEY,
+  badge_id         TEXT NOT NULL,
+  tag_uid          TEXT NOT NULL DEFAULT '',
+  ndef_url         TEXT NOT NULL DEFAULT '',
+  device_id        TEXT NOT NULL DEFAULT '',
+  write_status     TEXT NOT NULL DEFAULT '',
+  photo_object_key TEXT NOT NULL DEFAULT '',
+  written_at       DATETIME NOT NULL,
+  created_at       DATETIME NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_nfc_writes_badge_written ON nfc_writes(badge_id, written_at);
 `
 	if _, err := s.db.Exec(ddl); err != nil {
 		return err
@@ -339,4 +351,22 @@ func (s *Store) UpdateAutographStatus(ctx context.Context, id, status string) er
 		return ErrNotFound
 	}
 	return nil
+}
+
+// ----- NFC Writes -----
+
+func (s *Store) InsertNFCWrite(ctx context.Context, w *NFCWrite) error {
+	now := time.Now().UTC()
+	if w.ID == "" {
+		w.ID = newID("nfcw")
+	}
+	if w.WrittenAt.IsZero() {
+		w.WrittenAt = now
+	}
+	w.CreatedAt = now
+	_, err := s.db.ExecContext(ctx, `
+INSERT INTO nfc_writes(id,badge_id,tag_uid,ndef_url,device_id,write_status,photo_object_key,written_at,created_at)
+VALUES(?,?,?,?,?,?,?,?,?)`,
+		w.ID, w.BadgeID, w.TagUID, w.NDEFURL, w.DeviceID, w.WriteStatus, w.PhotoObjectKey, w.WrittenAt, w.CreatedAt)
+	return err
 }

--- a/internal/roundnfc/types.go
+++ b/internal/roundnfc/types.go
@@ -48,3 +48,15 @@ type AutographRequest struct {
 	CreatedAt      time.Time `json:"createdAt"`
 	UpdatedAt      time.Time `json:"updatedAt"`
 }
+
+type NFCWrite struct {
+	ID             string    `json:"id"`
+	BadgeID        string    `json:"badgeId"`
+	TagUID         string    `json:"tagUid"`
+	NDEFURL        string    `json:"ndefUrl"`
+	DeviceID       string    `json:"deviceId"`
+	WriteStatus    string    `json:"writeStatus"`
+	PhotoObjectKey string    `json:"photoObjectKey,omitempty"`
+	WrittenAt      time.Time `json:"writtenAt"`
+	CreatedAt      time.Time `json:"createdAt"`
+}


### PR DESCRIPTION
## What changed

- Added `POST /api/roundnfc/admin/uploads/presign` for 5-minute Tencent COS PUT presigned URLs.
- Added JWT-or-`X-App-Token` auth for RoundNFC admin management routes, with app tokens disabled when shorter than 16 characters.
- Added `POST /api/roundnfc/admin/nfc-writes` and an `nfc_writes` SQLite table for write metadata.
- Store only `photoObjectKey` in backend data and reject permanent URL values for that field.
- Added COS/app-token env template entries, CORS support for `X-App-Token`, and README deployment notes.

## Notes

For NFC write/user-download uploads, presign generation requires JPEG and produces `.jpg` object keys. Preview-style purposes may still use `.webp` or `.png`.

## Validation

- Inspected the local diff and committed from a clean cloned worktree.
- Could not run `gofmt` or `go test` locally because this Windows environment does not have `go`/`gofmt` on PATH.